### PR TITLE
replace final .git

### DIFF
--- a/lib/git.js
+++ b/lib/git.js
@@ -18,7 +18,7 @@ module.exports.getInfo = async () => {
   info.repo = gh.refs.push
     .replace('https://github.com/', '')
     .replace('git@github.com:', '')
-    .replace('.git', '')
+    .replace(/\.git$/, '')
 
   console.log(info)
 


### PR DESCRIPTION
hello,
had some trouble running hukum on the following repo:

https://github.com/christian-fei/christian-fei.github.io

the issue was that the first occurrence of `.git` was replaced (not the last occurrence), resulting in:

``` 
  repo: 'christian-fei/christian-feihub.io.git'
```

this should fix the issue